### PR TITLE
refactor: use functional component instead of class components

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@vieriksson/the-react-router",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3075,12 +3075,6 @@
       "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
       "dev": true
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
-    },
     "object-copy": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
@@ -3399,17 +3393,6 @@
         "sisteransi": "^1.0.0"
       }
     },
-    "prop-types": {
-      "version": "15.7.2",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
-      "integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.8.1"
-      }
-    },
     "psl": {
       "version": "1.1.31",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
@@ -3437,30 +3420,6 @@
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
       "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
-    },
-    "react": {
-      "version": "16.8.4",
-      "resolved": "https://registry.npmjs.org/react/-/react-16.8.4.tgz",
-      "integrity": "sha512-0GQ6gFXfUH7aZcjGVymlPOASTuSjlQL4ZtVC5YKH+3JL6bBLCVO21DknzmaPlI90LN253ojj02nsapy+j7wIjg==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.4"
-      }
-    },
-    "react-dom": {
-      "version": "16.8.4",
-      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-16.8.4.tgz",
-      "integrity": "sha512-Ob2wK7XG2tUDt7ps7LtLzGYYB6DXMCLj0G5fO6WeEICtT4/HdpOi7W/xLzZnR6RCG1tYza60nMdqtxzA8FaPJQ==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1",
-        "prop-types": "^15.6.2",
-        "scheduler": "^0.13.4"
-      }
     },
     "react-is": {
       "version": "16.8.4",
@@ -3713,16 +3672,6 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
       "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
       "dev": true
-    },
-    "scheduler": {
-      "version": "0.13.4",
-      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.13.4.tgz",
-      "integrity": "sha512-cvSOlRPxOHs5dAhP9yiS/6IDmVAVxmk33f0CtTJRkmUWcb1Us+t7b1wqdzoC0REw2muC9V5f1L/w5R5uKGaepA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      }
     },
     "semver": {
       "version": "5.6.0",
@@ -4298,9 +4247,9 @@
       }
     },
     "typescript": {
-      "version": "3.3.3333",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.3.3333.tgz",
-      "integrity": "sha512-JjSKsAfuHBE/fB2oZ8NxtRTk5iGcg6hkYXMnZ3Wc+b2RSqejEqTaem11mHASMnFilHrax3sLK0GDzcJrekZYLw==",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "version": "2.0.3",
   "scripts": {
     "test": "jest",
-    "compile": "npx tsc"
+    "compile": "tsc"
   },
   "author": "Vieriksson <me@viktoreriksson.se>",
   "bugs": {
@@ -20,14 +20,11 @@
     "@types/react": "^16.8.8",
     "@types/react-dom": "^16.8.2",
     "jest": "^24.5.0",
-    "react": "^16.8.4",
-    "react-dom": "^16.8.4",
     "ts-jest": "^24.0.0",
-    "typescript": "^3.3.3333"
+    "typescript": "^3.4.5"
   },
   "peerDependencies": {
-    "react": ">=16.8.4",
-    "path-to-regexp": ">=1.7.0"
+    "react": ">=16.8.4"
   },
   "homepage": "https://github.com/Vieriksson/the-react-router",
   "keywords": [
@@ -43,7 +40,7 @@
   },
   "jest": {
     "transform": {
-      "^.+\\.ts$": "<rootDir>/node_modules/ts-jest/preprocessor.js"
+      "^.+\\.ts$": "ts-jest"
     },
     "testRegex": "src/.*\\.(test|spec)\\.(ts|tsx|js)$",
     "testEnvironment": "jsdom",

--- a/src/events.ts
+++ b/src/events.ts
@@ -5,15 +5,15 @@ type Callback = ((state: RouterState) => void)
 export class RouterEvents {
   private listener: Callback[] = []
 
-  dispatch(data) {
+  dispatch(data: RouterState) {
     this.listener.forEach(callback => callback(data))
   }
 
-  addListener(callback) {
+  addListener(callback: Callback) {
     this.listener.push(callback)
   }
 
-  removeListener(callback) {
+  removeListener(callback: Callback) {
     const callbackIndex = this.listener.indexOf(callback)
     if (callbackIndex > -1) {
       this.listener.splice(callbackIndex, 1)

--- a/src/test/index.test.ts
+++ b/src/test/index.test.ts
@@ -8,7 +8,7 @@ test('should call listeners on dispatch', () => {
   })
 
   // Act
-  routerEvents.dispatch({})
+  routerEvents.dispatch({ url: '' })
 
   // Assert
   expect(mock.mock.calls.length).toBe(1)
@@ -22,10 +22,10 @@ test('should pass state as props to listeners on dispatch', () => {
   })
 
   // Act
-  routerEvents.dispatch({ a: 'b' })
+  routerEvents.dispatch({ url: 'b' })
 
   // Assert
-  expect(mock.mock.calls[0][0].a).toBe('b')
+  expect(mock.mock.calls[0][0].url).toBe('b')
 })
 
 test('should be able to call multiple listeners', () => {
@@ -40,7 +40,7 @@ test('should be able to call multiple listeners', () => {
   })
 
   // Act
-  routerEvents.dispatch({})
+  routerEvents.dispatch({ url: '' })
 
   // Assert
   expect(mock1.mock.calls.length).toBe(1)


### PR DESCRIPTION
I needed to use functions instead of classes due to a bug in mobx. 

Breaking changes:
1. I removed `withNavigation`. I do not see any reason to have it when you can use `useNavigation` but I might be wrong
2. I removed the props passing to the route component (see changes in `createElements`). I think you should use `useNavigation` instead.

I have testet it in episodehunter and it looks like it works but I can not promise anything.